### PR TITLE
Allow deployments to test.geek.zone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 
 orbs:
   python: circleci/python@0.2.1
+  aws-ecr: circleci/aws-ecr@6.9.1
+  kubernetes: circleci/kubernetes@0.11.0
 
 jobs:
   build-and-test:
@@ -11,11 +13,69 @@ jobs:
       - python/load-cache
       - python/install-deps
       - python/save-cache
+      - run: ./manage.py test
+  deploy:
+    executor: python/default
+    steps:
+      - checkout
+      - kubernetes/install-kubectl
       - run:
-          command: ./manage.py test
-          name: Test
+          name: Fill out template variables in yml files
+          command: |
+            # Required for envsubst
+            sudo apt install gettext-base
+            envsubst < k8s/deployment.yml > k8s/final.yml
+      - run:
+          name: connect to k8s cluster
+          command: |
+            pip3 install awscli
+            aws eks --region eu-west-2 update-kubeconfig --name gz-test
+      - kubernetes/create-or-update-resource:
+          get-rollout-status: true
+          resource-file-path: k8s/final.yml
+          resource-name: deployment/gz-web
 
 workflows:
+  version: 2
   main:
     jobs:
       - build-and-test
+      - aws-ecr/build-and-push-image:
+          name: build-publish-django
+          account-url: AWS_ECR_ACCOUNT_URL
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          create-repo: true
+          dockerfile: docker/backend/Dockerfile
+          path: .
+          region: AWS_REGION
+          repo: gz-web-django
+          tag: "latest,$CIRCLE_WORKFLOW_ID"
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
+      - aws-ecr/build-and-push-image:
+          name: build-publish-proxy
+          account-url: AWS_ECR_ACCOUNT_URL
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          create-repo: true
+          dockerfile: docker/proxy/Dockerfile
+          path: .
+          region: AWS_REGION
+          repo: gz-nginx-proxy
+          tag: "latest,$CIRCLE_WORKFLOW_ID"
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - build-publish-django
+            - build-publish-proxy
+          filters:
+            branches:
+              only: master

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8-alpine
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install gunicorn
+
+CMD [ "gunicorn", "web.wsgi", "-b 0.0.0.0:8000" ]

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.8-alpine
+
+WORKDIR /usr/src/app
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+RUN ["python", "manage.py", "collectstatic"]
+
+FROM nginx:alpine
+
+COPY docker/proxy/nginx.conf /etc/nginx/templates/nginx.conf.template
+COPY --from=0 /usr/src/app/static /var/www/static
+RUN rm /etc/nginx/conf.d/default.conf

--- a/docker/proxy/nginx.conf
+++ b/docker/proxy/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+
+    location / {
+        # this is localhost because gunicorn is
+        # hosted in the same pod.
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /static {
+        alias /var/www/static/;
+    }
+}

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gz-web
+  labels:
+    app: gz-web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gz-web
+  template:
+    metadata:
+      labels:
+        app: gz-web
+    spec:
+      containers:
+      - name: django-backend
+        image: 098281131088.dkr.ecr.eu-west-2.amazonaws.com/gz-web-django:${CIRCLE_WORKFLOW_ID}
+      - name: nginx-proxy
+        image: 098281131088.dkr.ecr.eu-west-2.amazonaws.com/gz-nginx-proxy:${CIRCLE_WORKFLOW_ID}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gz-web-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: gz-web
+  ports:
+  - port: 80
+    targetPort: 80

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ What things you need to install the software and how to install them
 
 
 
-Windows users should install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). 
+Windows users should install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
 ### Suggestions
 
@@ -41,17 +41,35 @@ Also, do join us on our [Discord](https://geek.zone/discord)!
 
 Nothing project specific yet, just getting started right now. Follow the above to install the prerequisites and take a look at the issues that need to be resolved!
 
-## Running the Tests
+## Local Development
+
+### Running the Tests
 
 We have not got any tests for you right now. This readme will be kept up to date so check back when it does.
 
+### Changing the CircleCI Build
+
+I have found the [circleci local cli tool](https://circleci.com/docs/2.0/local-cli/) to be very useful when making changes to the circle build locally. The errors can be a bit cryptic, but it's easier than debugging basic syntax issues from within the circleci console.
+
+### Running Kubernetes files locally
+
+The kubernetes files are not optimised for being run locally (yet), but you should be able to get them working with minimal local changes.
+
+We use envsubst in the build to replace the image tag numbers in the kubernetes yaml files. You can run the same command locally if you wish.
+
+```sh
+CIRCLE_WORKFLOW_ID=1 envsubst < k8s/deployment.yml | kubectl apply -f -
+```
+
 ## Deployment
 
-We are working on the deployment mechanism at the moment. AWS FTW.
+The code is currently deployed onto a test Kubernetes cluster hosted using AWS Elastic Kubernetes Service (EKS). Our CI/CD service [circleci](https://circleci.com/) will deploy any code changes to [test.geek.zone](http://test.geek.zone/) on a merge to master.
+
+The deployment files can be found under the `k8s` folder.
 
 ## Contributing
 
-No special rules, just pull reqeust before merging, you know the drill ;)
+No special rules, just pull request before merging, you know the drill ;)
 
 ## License
 

--- a/web/settings.py
+++ b/web/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = ')i@@^(m2b0jalyaa)r$2wg6o&mjb*rm_+cm9g03hyt=j61i2u('
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['test.geek.zone']
 
 
 # Application definition
@@ -118,3 +118,4 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = 'static/'


### PR DESCRIPTION
Resolves #4.

This pull request allows members and contributors to deploy their changes to
a testing environment.

The testing environment is currently a temporary Kubernetes cluster
hosted on AWS using their Elastic Kubernetes Service (EKS).

CircleCI builds docker images of the django web app and an nginx proxy
and then pushes them up to the GeekZone Elastic Container
Registry (ECR). CircleCI then applies the kuberenetes configuration
located in the `k8s` folder to the kubernetes cluster.

Docker images are tagged with the circleci workflow id which is unqiue
to every run of the pipeline.

The django service is run using Gunicorn and all requests to it are
proxied via nginx which serves static assets. There might be a better
way of doing this in the long term?