### PR TITLE
Fix registration and login broken

### DIFF
--- a/memberships/forms.py
+++ b/memberships/forms.py
@@ -51,7 +51,7 @@ class RegistrationForm(forms.Form):
         password = self.cleaned_data.get("password")
         password_validation.validate_password(password, None)
 
-        return self.cleaned_data
+        return self.cleaned_data["password"]
 
     def clean_email(self):
         if Member.objects.filter(email=self.cleaned_data["email"]).exists():

--- a/memberships/tests/test_login_form.py
+++ b/memberships/tests/test_login_form.py
@@ -1,0 +1,39 @@
+from django.urls import reverse
+from .utils import StripeTestCase
+
+class LoginFormTestCase(StripeTestCase):
+    def setUp(self):
+        self.setup_stripe_mocks()
+
+    def tearDown(self):
+        self.tear_down_stripe_mocks()
+
+    def test_newly_registered_user_can_login(self):
+        # Register a user using the form
+        response = self.client.post(
+            reverse("register"),
+            {
+                "full_name": "test person",
+                "email": "test@example.com",
+                "password": "k38m1KIhIUzeA^UL",
+                "birth_date": "1991-01-01",
+                "constitution_agreed": "on",
+            },
+            follow=True
+        )
+        self.assertTrue(response.context["user"].is_authenticated)
+
+        # Log them out
+        response = self.client.get(reverse("memberships_logout"), follow=True)
+        self.assertFalse(response.context["user"].is_authenticated)
+
+        # Log them back in using the login form
+        response = self.client.post(
+            reverse("memberships_login"),
+            {
+                "username": "test@example.com",
+                "password": "k38m1KIhIUzeA^UL"
+            },
+            follow=True
+        )
+        self.assertTrue(response.context["user"].is_authenticated)


### PR DESCRIPTION
It appeared that login broke after merging issue39. It turns out that
the `clean_password` function was incorrectly dealt with during a
merge conflict and so was returning the entire form data instead of
the plaintext password.

This still allowed someone to register and be auto logged in, but they
were unable to login manually.