### PR TITLE
Assigning permission to members who have payed

### DIFF
--- a/funky_time.py
+++ b/funky_time.py
@@ -1,7 +1,9 @@
 #  handy functions for doing the heavy lifting in the nightmare that is the global datetime system
 
 from datetime import datetime
+from django.utils.timezone import make_aware
 from time import gmtime
+from  web.settings import TIME_ZONE
 
 from django.utils.timezone import make_aware
 

--- a/funky_time.py
+++ b/funky_time.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from django.utils.timezone import make_aware
 from time import gmtime
-from  web.settings import TIME_ZONE
+from web.settings import TIME_ZONE
 
 from django.utils.timezone import make_aware
 

--- a/memberships/tests/test_stripe_webhooks.py
+++ b/memberships/tests/test_stripe_webhooks.py
@@ -136,4 +136,4 @@ class CheckoutCompletedWebhookTestCase(StripeTestCase):
         user = User.objects.get(id=self.member.user_id)
         perm = Permission.objects.get(codename="has_sand_membership")
 
-        self.assertEqual(True, user.has_perm('memberships.has_sand_membership'))
+        self.assertEqual(True, user.has_perm("memberships.has_sand_membership"))

--- a/memberships/tests/test_stripe_webhooks.py
+++ b/memberships/tests/test_stripe_webhooks.py
@@ -133,7 +133,7 @@ class CheckoutCompletedWebhookTestCase(StripeTestCase):
             },
             content_type="application/json",
         )
-        perm = Permission.objects.get(codename="has_sand_membership")
         user = User.objects.get(id=self.member.user_id)
+        perm = Permission.objects.get(codename="has_sand_membership")
 
-        self.assertEqual(True, user.has_perm("has_sand_membership"))
+        self.assertEqual(True, user.has_perm('memberships.has_sand_membership'))

--- a/memberships/tests/test_stripe_webhooks.py
+++ b/memberships/tests/test_stripe_webhooks.py
@@ -71,7 +71,6 @@ class CheckoutCompletedWebhookTestCase(StripeTestCase):
             content_type="application/json",
         )
         memberships = Membership.objects.filter(member=self.member)
-
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, memberships.count())
 

--- a/memberships/tests/test_stripe_webhooks.py
+++ b/memberships/tests/test_stripe_webhooks.py
@@ -134,6 +134,5 @@ class CheckoutCompletedWebhookTestCase(StripeTestCase):
             content_type="application/json",
         )
         user = User.objects.get(id=self.member.user_id)
-        perm = Permission.objects.get(codename="has_sand_membership")
 
         self.assertEqual(True, user.has_perm("memberships.has_sand_membership"))

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -189,7 +189,7 @@ def stripe_webhook(request):
             )
         if event["type"] == "invoice.payment_succeeded":
             member = Member.objects.get(email=event["data"]["object"]["customer_email"])
-            log_payment(event)
+            log_payment(event, member)
             update_last_payment(event, member)
             add_user_sand_permission(member)
 

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
-from django.contrib.auth.models import Permission, User
 from urllib.parse import parse_qs, urlparse
 
 import urllib.request
@@ -15,8 +14,9 @@ from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 
 from funky_time import epoch_to_datetime
+from payments import handle_stripe_payment
 from .forms import *
-from .models import Member, Membership, FailedPayment, Payment
+from .models import Member, Membership
 from .services import StripeGateway
 
 
@@ -181,42 +181,11 @@ def stripe_webhook(request):
             json.loads(request.body), settings.STRIPE_SECRET_KEY
         )
         stripe_webhook = StripeWebhook()
-        if event["type"] == "invoice.payment_failed":
-            f_payment = FailedPayment.objects.create(
-                stripe_customer_id=event["data"]["object"]["customer"],
-                stripe_subscription_id=event["data"]["object"]["subscription"],
-                stripe_event_type=event["type"],
-            )
-        if event["type"] == "invoice.payment_succeeded":
-            member = Member.objects.get(email=event["data"]["object"]["customer_email"])
-            log_payment(event, member)
-            update_last_payment(event, member)
-            add_user_sand_permission(member)
+        handle_stripe_payment(event)
 
         return stripe_webhook.handle(event)
     except ValueError as e:
         return HttpResponse("Failed to parse stripe payload", status=400)
-
-
-def log_payment(event, member):
-    payment = Payment.objects.create(
-        member=member,
-        stripe_subscription_id=event["data"]["object"]["subscription"],
-    )
-
-
-def update_last_payment(event, member):
-    # Store payment DateTime in membership model
-    membership = Membership.objects.get(member=member)
-    membership.last_payment_time = epoch_to_datetime(event["created"])
-    membership.save()
-
-
-def add_user_sand_permission(member):
-    # Give user 'has_sand_membership' permission
-    user = User.objects.get(id=member.user_id)
-    perm = Permission.objects.get(codename="has_sand_membership")
-    user.user_permissions.add(perm)
 
 
 @login_required()

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -204,11 +204,13 @@ def log_payment(event, member):
         stripe_subscription_id=event["data"]["object"]["subscription"],
     )
 
+
 def update_last_payment(event, member):
     # Store payment DateTime in membership model
     membership = Membership.objects.get(member=member)
     membership.last_payment_time = epoch_to_datetime(event["created"])
     membership.save()
+
 
 def add_user_sand_permission(member):
     # Give user 'has_sand_membership' permission

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -199,6 +199,11 @@ def stripe_webhook(request):
             membership.last_payment_time = epoch_to_datetime(event["created"])
             membership.save()
 
+            # Give user 'has_sand_membership' permission
+            user = User.objects.get(id=member.user_id)
+            perm = Permission.objects.get(codename="has_sand_membership")
+            user.user_permissions.add(perm)
+
         return stripe_webhook.handle(event)
     except ValueError as e:
         return HttpResponse("Failed to parse stripe payload", status=400)

--- a/payments.py
+++ b/payments.py
@@ -1,26 +1,26 @@
 from django.contrib.auth.models import Permission, User
 
-from .models import Member, Membership, FailedPayment, Payment
+from memberships.models import Member, Membership, FailedPayment, Payment
 from funky_time import epoch_to_datetime
 
 
 def handle_stripe_payment(event):
     if event["type"] == "invoice.payment_failed":
-        f_payment = FailedPayment.objects.create(
+        FailedPayment.objects.create(
             stripe_customer_id=event["data"]["object"]["customer"],
             stripe_subscription_id=event["data"]["object"]["subscription"],
             stripe_event_type=event["type"],
         )
-        if event["type"] == "invoice.payment_succeeded":
-            member = Member.objects.get(email=event["data"]["object"]["customer_email"])
-            log_payment(event, member)
-            update_last_payment(event, member)
-            add_user_sand_permission(member)
+    if event["type"] == "invoice.payment_succeeded":
+        member = Member.objects.get(email=event["data"]["object"]["customer_email"])
+        log_payment(event, member)
+        update_last_payment(event, member)
+        add_user_sand_permission(member)
 
 
 def log_payment(event, member):
     # Log payment for a member in the database
-    payment = Payment.objects.create(
+    Payment.objects.create(
         member=member,
         stripe_subscription_id=event["data"]["object"]["subscription"],
     )

--- a/payments.py
+++ b/payments.py
@@ -1,0 +1,40 @@
+from django.contrib.auth.models import Permission, User
+
+from .models import Member, Membership, FailedPayment, Payment
+from funky_time import epoch_to_datetime
+
+
+def handle_stripe_payment(event):
+    if event["type"] == "invoice.payment_failed":
+        f_payment = FailedPayment.objects.create(
+            stripe_customer_id=event["data"]["object"]["customer"],
+            stripe_subscription_id=event["data"]["object"]["subscription"],
+            stripe_event_type=event["type"],
+        )
+        if event["type"] == "invoice.payment_succeeded":
+            member = Member.objects.get(email=event["data"]["object"]["customer_email"])
+            log_payment(event, member)
+            update_last_payment(event, member)
+            add_user_sand_permission(member)
+
+
+def log_payment(event, member):
+    # Log payment for a member in the database
+    payment = Payment.objects.create(
+        member=member,
+        stripe_subscription_id=event["data"]["object"]["subscription"],
+    )
+
+
+def update_last_payment(event, member):
+    # Store payment DateTime in membership model
+    membership = Membership.objects.get(member=member)
+    membership.last_payment_time = epoch_to_datetime(event["created"])
+    membership.save()
+
+
+def add_user_sand_permission(member):
+    # Give user 'has_sand_membership' permission
+    user = User.objects.get(id=member.user_id)
+    perm = Permission.objects.get(codename="has_sand_membership")
+    user.user_permissions.add(perm)


### PR DESCRIPTION
When a member has paid for their sand membership they are given the `has_sand_membership` permission.

The intended use is to easily be able to identify which members have paid (and which have not).

Fixes #89 
Fixes #195 
Potentially relates to #223 