### PR TITLE
Make epoch_to_datetime utility timezone aware

### DIFF
--- a/funky_time.py
+++ b/funky_time.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from time import gmtime
 
+from django.utils.timezone import make_aware
 
 # what date is x years from a given date?
 def years_ago(years: int, from_date: datetime = None):
@@ -29,4 +30,4 @@ def date_to_datetime(date):
 
 
 def epoch_to_datetime(time):
-    return datetime.fromtimestamp(time)
+    return make_aware(datetime.fromtimestamp(time))


### PR DESCRIPTION
It seems that this recently started erroring in our tests, although I'm not quite sure how.

This patch is taken as a suggestion from
https://stackoverflow.com/questions/18622007/runtimewarning-datetimefield-received-a-naive-datetime

I get the impression that we should make the entire funky_time file timezone aware, but I have held off doing that until we have further evidence that doing so is required.