### PR TITLE
Allow donations to be decimals

### DIFF
--- a/memberships/services.py
+++ b/memberships/services.py
@@ -18,13 +18,19 @@ class StripeGateway:
         customer = stripe.Customer.create(email=email)
         return customer.id
 
-    def create_checkout_session(self, member, success_url, cancel_url):
+    def create_checkout_session(self, member, success_url, cancel_url, donation):
         session = stripe.checkout.Session.create(
             payment_method_types=["bacs_debit"],
             mode="setup",
             customer=member.stripe_customer_id,
             success_url=success_url,
             cancel_url=cancel_url,
+            # line_items=[{
+            #     'amount': donation,
+            #     'currency': 'gbp',
+            #     'quantity': 1,
+            #     'name': 'Donation',
+            # }]
         )
         return session.id
 
@@ -35,7 +41,7 @@ class StripeGateway:
         items = [{"price": self.sand_price_id}]
         if donation:
             price = stripe.Price.create(
-                unit_amount=donation * 100,
+                unit_amount_decimal=donation,
                 currency="gbp",
                 recurring={"interval": "year"},
                 product=self.donation_product_id,

--- a/memberships/services.py
+++ b/memberships/services.py
@@ -18,7 +18,7 @@ class StripeGateway:
         customer = stripe.Customer.create(email=email)
         return customer.id
 
-    def create_checkout_session(self, member, success_url, cancel_url, donation):
+    def create_checkout_session(self, member, success_url, cancel_url):
         session = stripe.checkout.Session.create(
             payment_method_types=["bacs_debit"],
             mode="setup",
@@ -34,14 +34,14 @@ class StripeGateway:
         )
         return session.id
 
-    def create_subscription(self, setup_intent, donation=None):
+    def create_subscription(self, setup_intent, donation):
         intent = stripe.SetupIntent.retrieve(setup_intent)
         customer = stripe.Customer.retrieve(intent.customer)
 
         items = [{"price": self.sand_price_id}]
         if donation:
             price = stripe.Price.create(
-                unit_amount_decimal=donation,
+                unit_amount_decimal=float(donation) / 100,
                 currency="gbp",
                 recurring={"interval": "year"},
                 product=self.donation_product_id,

--- a/memberships/services.py
+++ b/memberships/services.py
@@ -25,12 +25,6 @@ class StripeGateway:
             customer=member.stripe_customer_id,
             success_url=success_url,
             cancel_url=cancel_url,
-            # line_items=[{
-            #     'amount': donation,
-            #     'currency': 'gbp',
-            #     'quantity': 1,
-            #     'name': 'Donation',
-            # }]
         )
         return session.id
 
@@ -41,10 +35,10 @@ class StripeGateway:
         items = [{"price": self.sand_price_id}]
         if donation:
             price = stripe.Price.create(
+                product=self.donation_product_id,
                 unit_amount_decimal=float(donation) / 100,
                 currency="gbp",
                 recurring={"interval": "year"},
-                product=self.donation_product_id,
             )
             items.append({"price": price.id})
 

--- a/memberships/tests/test_registration_form.py
+++ b/memberships/tests/test_registration_form.py
@@ -189,7 +189,8 @@ class DonationConfirmPageTestCase(StripeTestCase):
         response = self.client.get(reverse("confirm"))
         self.assertContains(response, "Your sand membership will cost £1 a year")
         self.assertContains(
-            response, "This is made up of a £1 Sand membership charge with no donation"
+            response,
+            "This is made up of a £1 Sand membership charge and a £0.00 donation",
         )
 
     @mock.patch("django.conf.settings.STRIPE_PUBLIC_KEY", "example_stripe_key")

--- a/memberships/tests/test_registration_form.py
+++ b/memberships/tests/test_registration_form.py
@@ -179,15 +179,15 @@ class DonationConfirmPageTestCase(StripeTestCase):
 
     def test_total_with_donation_shows_correct_amount(self):
         response = self.client.get("{}?donation={}".format(reverse("confirm"), 10))
-        self.assertContains(response, "Your sand membership will cost £11 a year")
+        self.assertContains(response, "Your sand membership will cost £11.00 a year")
         self.assertContains(
             response,
-            "This is made up of a £1 Sand membership charge and a £10 donation",
+            "This is made up of a £1 Sand membership charge and a £10.00 donation",
         )
 
     def test_total_without_donation_shows_correct_amount(self):
         response = self.client.get(reverse("confirm"))
-        self.assertContains(response, "Your sand membership will cost £1 a year")
+        self.assertContains(response, "Your sand membership will cost £1.00 a year")
         self.assertContains(
             response,
             "This is made up of a £1 Sand membership charge and a £0.00 donation",
@@ -218,15 +218,15 @@ class DonationConfirmPageTestCase(StripeTestCase):
     def test_users_with_a_donation_are_sent_to_the_correct_cancel_and_success_urls(
         self,
     ):
-        response = self.client.get("{}?donation=10".format(reverse("confirm")))
+        response = self.client.get("{}?donation=10.0".format(reverse("confirm")))
         _, kwargs = self.create_checkout_session.call_args
         self.assertEqual(
             kwargs["cancel_url"],
-            "http://testserver{}?donation=10".format(reverse("confirm")),
+            "http://testserver{}?donation=10.0".format(reverse("confirm")),
         )
         self.assertEqual(
             kwargs["success_url"],
-            "http://testserver{}?donation=10".format(reverse("memberships_settings")),
+            "http://testserver{}?donation=10.0".format(reverse("memberships_settings")),
         )
 
 

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -143,7 +143,7 @@ def register(request):
         user.member.preferred_name, user.member.email, "Welcome", message
     )
 
-    donation = int(float(request.POST.get("donation")) * float('100'))
+    donation = int(float(request.POST.get("donation")) * float("100"))
 
     if donation:
         confirmation_url = "{}?donation={}".format(reverse("confirm"), int(donation))
@@ -160,7 +160,6 @@ def confirm(request):
     if donation:
         if float(donation) > 0:
             donation = float(round(float(request.GET.get("donation")), 2)) / 100
-    
 
     total = 1 if not donation else donation + 1
 
@@ -179,7 +178,7 @@ def confirm(request):
         member=request.user.member,
         success_url=request.build_absolute_uri(success_url),
         cancel_url=request.build_absolute_uri(cancel_url),
-        donation=float(donation / 100)
+        donation=float(donation / 100),
     )
     if not donation:
         donation = 0
@@ -188,7 +187,7 @@ def confirm(request):
         request,
         "memberships/confirm.html",
         {
-            "donation": "%.2f" %  donation,
+            "donation": "%.2f" % donation,
             "total": "%.2f" % float(total),
             "stripe_public_key": settings.STRIPE_PUBLIC_KEY,
             "stripe_session_id": session_id,

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -149,27 +149,27 @@ def register(request):
         confirmation_url = "{}?donation={}".format(reverse("confirm"), int(donation))
         return HttpResponseRedirect(confirmation_url)
 
-    return HttpResponseRedirect(reverse("confirm"))
+    return HttpResponseRedirect(reverse("confirm"), int(donation))
 
 
 def confirm(request):
     if not request.user.is_authenticated:
         return HttpResponseRedirect(reverse("register"))
 
-    donation = int(request.GET.get("donation"))
+    donation = request.GET.get("donation")
     if donation:
         if float(donation) > 0:
-            donation = float(round(float(request.GET.get("donation")), 2)) / 100
+            donation = round((float(donation) / 100), 2)
 
     total = 1 if not donation else donation + 1
 
     cancel_url = (
-        "{}?donation={}".format(reverse("confirm"), int(donation))
+        "{}?donation={}".format(reverse("confirm"), int(donation * 100))
         if donation
         else reverse("confirm")
     )
     success_url = (
-        "{}?donation={}".format(reverse("memberships_settings"), int(donation))
+        "{}?donation={}".format(reverse("memberships_settings"), int(donation * 100))
         if donation
         else reverse("memberships_settings")
     )
@@ -178,7 +178,6 @@ def confirm(request):
         member=request.user.member,
         success_url=request.build_absolute_uri(success_url),
         cancel_url=request.build_absolute_uri(cancel_url),
-        donation=float(donation / 100),
     )
     if not donation:
         donation = 0

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -157,7 +157,11 @@ def confirm(request):
         return HttpResponseRedirect(reverse("register"))
 
     donation = request.GET.get("donation")
-    total = 1 if not donation else int(donation) + 1
+    if donation:
+        if float(donation) > 0:
+            donation = round(float(request.GET.get("donation")), 2)
+
+    total = 1 if not donation else donation + 1
 
     cancel_url = (
         "{}?donation={}".format(reverse("confirm"), donation)
@@ -175,13 +179,15 @@ def confirm(request):
         success_url=request.build_absolute_uri(success_url),
         cancel_url=request.build_absolute_uri(cancel_url),
     )
+    if not donation:
+        donation = 0
 
     return render(
         request,
         "memberships/confirm.html",
         {
-            "donation": donation,
-            "total": total,
+            "donation": "%.2f" % float(donation),
+            "total": "%.2f" % float(total),
             "stripe_public_key": settings.STRIPE_PUBLIC_KEY,
             "stripe_session_id": session_id,
             "recaptcha_site_key": settings.RECAPTCHA_SITE_KEY,

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -161,7 +161,7 @@ def confirm(request):
         if float(donation) > 0:
             donation = round(float(request.GET.get("donation")), 2)
 
-    total = 1 if not donation else donation + 1
+    total = 1 if not donation else int(donation) + 1
 
     cancel_url = (
         "{}?donation={}".format(reverse("confirm"), donation)


### PR DESCRIPTION
Currently a `500` error is thrown when a decimal is given as a donation value when registering.

This allows members to submit decimals, such as `5.5` or `5.21` if wanted.

Fixes #364 