### PR TITLE
Add workflow for posting issue closed notification

### DIFF
--- a/.github/workflows/issue_closed_notification.yml
+++ b/.github/workflows/issue_closed_notification.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on : ubuntu-latest
     steps:
       - name: Post message
-        uses: mohan-13/issue-closed-notification@master
+        uses: mohan-13/issue-closed-notification-action@master
         with:
           discord-webhook-url: ${{ secrets.DISCORD_DEV_WEBHOOK }}

--- a/.github/workflows/issue_closed_notification.yml
+++ b/.github/workflows/issue_closed_notification.yml
@@ -1,0 +1,16 @@
+name: Issue Closed Notification
+
+# This workflow runs whenever an issue is closed
+on:
+  issues:
+    types: ["closed"]
+
+jobs:
+  post-message:
+    name: Post Celebration Message
+    runs-on : ubuntu-latest
+    steps:
+      - name: Post message
+        uses: mohan-13/issue-closed-notification@master
+        with:
+          discord-webhook-url: ${{ secrets.DISCORD_DEV_WEBHOOK }}

--- a/.github/workflows/issue_closed_notification.yml
+++ b/.github/workflows/issue_closed_notification.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   post-message:
-    name: Post Celebration Message
+    name: Post Celebration Message to Discord
     runs-on : ubuntu-latest
     steps:
       - name: Post message

--- a/.github/workflows/issue_closed_notification.yml
+++ b/.github/workflows/issue_closed_notification.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on : ubuntu-latest
     steps:
       - name: Post message
-        uses: mohan-13/issue-closed-notification-action@master
+        uses: mohan-13/issue-closed-notification-action@v1.0.0
         with:
           discord-webhook-url: ${{ secrets.DISCORD_DEV_WEBHOOK }}

--- a/.github/workflows/issue_closed_notification.yml
+++ b/.github/workflows/issue_closed_notification.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on : ubuntu-latest
     steps:
       - name: Post message
-        uses: mohan-13/issue-closed-notification-action@v1.0.0
+        uses: mohan-13/issue-closed-notification-action@v1.0.1
         with:
           discord-webhook-url: ${{ secrets.DISCORD_DEV_WEBHOOK }}


### PR DESCRIPTION
## Description
A new workflow has been added which uses an action to post celebration message to discord channel. Please find the action [here](https://github.com/marketplace/actions/issue-closed-notification).
### Screenshot of the message posted: 
<img width="1143" alt="Sample Messages posted" src="https://user-images.githubusercontent.com/31698165/139379528-0e0ac1cc-ee60-4a91-b482-ae64c02f3004.png">

## Related Issue
Resolves #425 

## Motivation and Context
Whenever an issue has been successfully closed it posts a random celebration message with the assignee name and issue link.

## How Has This Been Tested?
Tested multiple times by opening a test issue and closing it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
