### PR TITLE
Add .sonarcloud.properties file to specify parameters for Sonarcloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,7 +4,7 @@ sonar.sources=.
 #sonar.inclusions=
 
 # Path to tests
-sonar.tests=test-results
+# sonar.tests=
 #sonar.test.exclusions=
 #sonar.test.inclusions=
 

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,18 @@
+# Path to sources
+sonar.sources=.
+#sonar.exclusions=
+#sonar.inclusions=
+
+# Path to tests
+sonar.tests=test-results
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=
+
+# Python version for code analysis
+sonar.python.version=3.9 


### PR DESCRIPTION
A .sonarcloud.properties file is needed for Sonarcloud to get parameters for its code analysis. 

## Related Issue
<!--- Link the issue here using the format "resolves #492" -->

## Motivation and Context
This is needed to get rid of the warning appearing in the Sonarcloud console related to Python version not specified.

## How Has This Been Tested?
This can only be tested after raising the PR and get Sonarcloud analyse it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/GeekZoneHQ/web/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
