### PR TITLE
Closes #633 Tests not passing locally but are in CI - updated

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,8 +93,8 @@ DATABASE_NAME=postgres
 DATABASE_HOST=localhost
 DATABASE_PASSWORD=postgres
 DATABASE_PORT=5432
-TEST_USER_PASSWORD=LegitLong@@Pword11
-TEST_USER_PASSWORD_BAD=pass
+TEST_USER_PASSWORD=k38m1KIhIUzeA^UL
+TEST_USER_PASSWORD_BAD=password
 EOF
 ```
 17. Run the database migrations `python3 manage.py migrate`
@@ -138,8 +138,8 @@ DATABASE_NAME=postgres
 DATABASE_HOST=localhost
 DATABASE_PASSWORD=postgres
 DATABASE_PORT=5432
-TEST_USER_PASSWORD=LegitLong@@Pword11
-TEST_USER_PASSWORD_BAD=pass" | tee web/.env
+TEST_USER_PASSWORD=k38m1KIhIUzeA^UL
+TEST_USER_PASSWORD_BAD=password" | tee web/.env
 ``` 
 11. Install the project dependencies `pip install -r requirements.txt`
 12. Run the database migrations `python manage.py migrate`


### PR DESCRIPTION
Replaces https://github.com/GeekZoneHQ/web/pull/664

This pull request pulls from a new branch added as GeekZoneHQ/web:doc-633-tests_not_passing_locally, instead of my own forked repository used in the previous pull request: anettleship/GeekZone-web-adrian/tree/doc-633-tests_not_passing_locally. In the previous PR we ran into a CircleCI issue because I had issued the pull request from my own github account rather than a added within GeekZoneHQ/web.

--

[Problem: ](https://github.com/GeekZoneHQ/web/issues/633)
When running python3 manage.py test locally in WSL, it runs all 33 tests but FAILED (failures=1, errors=6)
The same tests are all passing in CircleCI.

Solution
Amend project readme.md file, where dev set up is documented, to instruct user to create test user environment variables for TEST_USER_PASSWORD and TEST_USER_PASSWORD_BAD in web/.env to align with values currently present in web/.env.dev.

<!--- Describe your changes in detail. -->

The readme directs the user to create a file at web/.env with the following commands listed below. These do not currently create the two environment variables and values:

TEST_USER_PASSWORD=k38m1KIhIUzeA^UL
TEST_USER_PASSWORD_BAD=password

When tests run locally, these environment variables are null. This caused the errors reported in the bug report (failures=1, errors=6). For the failing test: test_signed_in_users_cannot_register, the test failed as it was unable to login successfully with a null password, so after failing to log in, the test was able to register a new user, so it returned http 200 for success rather than the 302 redirect.

I have amended the two commands provided in the readme that create the .env file for unix and windows users from and to...

Windows Before:

echo "DEBUG=1
DATABASE_USER=postgres
DATABASE_NAME=postgres
DATABASE_HOST=localhost
DATABASE_PASSWORD=postgres
DATABASE_PORT=5432" | tee web/.env


Windows After:

echo "DEBUG=1
DATABASE_USER=postgres
DATABASE_NAME=postgres
DATABASE_HOST=localhost
DATABASE_PASSWORD=postgres
DATABASE_PORT=5432
TEST_USER_PASSWORD=k38m1KIhIUzeA^UL
TEST_USER_PASSWORD_BAD=password" | tee web/.env


Unix Before:

cat <<EOF > web/.env
DEBUG=1
DATABASE_USER=postgres
DATABASE_NAME=postgres
DATABASE_HOST=localhost
DATABASE_PASSWORD=postgres
DATABASE_PORT=5432
EOF


Unix After:

cat <<EOF > web/.env
DEBUG=1
DATABASE_USER=postgres
DATABASE_NAME=postgres
DATABASE_HOST=localhost
DATABASE_PASSWORD=postgres
DATABASE_PORT=5432
TEST_USER_PASSWORD=k38m1KIhIUzeA^UL
TEST_USER_PASSWORD_BAD=password
EOF

## Related Issue

https://github.com/GeekZoneHQ/web/issues/633

## Motivation and Context
Tests were failing, now they pass.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tested this fully on Linux to determine that the tests fail in the expected places following the readme and using the first command, but when the .env file is created with the amended command instead - i.e. the two new environment variable are present in web/.env, all tests pass.

![Screenshot from 2023-05-15 17-46-13](https://github.com/GeekZoneHQ/web/assets/5358837/11e4eb2c-87b4-4596-84aa-48affaef0272)

On Windows I have tested the powershell command to ensure that the .env file is created correctly with the additional lines, but I have not set up the project and run the tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - change to documentation only
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. 
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/GeekZoneHQ/contributing)** document.
- [ ] I have added tests to cover my changes - no new code.
- [x] All new and existing tests passed.
