### PR TITLE
Add branch name filter in cicd pipeline, update Python version, switch from psycopg2-binary to psycopg2, change executor in cicd pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ jobs:
       TAG: 0.1.<< pipeline.number >>
     steps:
       - checkout
-      # - setup_remote_docker:
-      #     version: 20.10.7
+      - setup_remote_docker:
+          version: 20.10.14
       - run:
           name: Skip ci
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,15 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Skip ci
+          command: |
+            if [[ "$CIRCLE_BRANCH" =~ ^doc.*$ ]]; then
+              echo 'Just updating the documentation, no need to run the pipeline'
+              exit 0
+            else
+              echo 'Running the pipeline to build a new image'
+            fi
+      - run:
           name: Download and configure Snyk CLI
           command: |
             curl https://static.snyk.io/cli/latest/snyk-linux -o snyk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build-test-publish:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2204:2023.04.2
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
@@ -60,7 +60,7 @@ jobs:
             docker push geekzone/backend:$TAG
   just-fail:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2204:2023.04.2
     steps:
       - run:
           name: This branch is not allowed to merge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,14 @@
 version: 2.1
 jobs:
   build-test-publish:
-    machine:
-      image: ubuntu-2204:2023.04.2
+    docker:
+      - image: cimg/base:2021.04
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 20.10.7
       - run:
           name: Skip ci
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           command: |
             if [[ "$CIRCLE_BRANCH" =~ ^doc.*$ ]]; then
               echo 'Just updating the documentation, no need to run the pipeline'
-              exit 0
+              circleci-agent step halt
             else
               echo 'Running the pipeline to build a new image'
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,10 +147,6 @@ workflows:
   main-web:
     jobs:
       - build-test-publish:
-          filters:
-            branches:
-              ignore:
-                - /^doc-.*/
           context:
             - org-global
       - just-fail:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@ version: 2.1
 jobs:
   build-test-publish:
     docker:
-      - image: cimg/base:2021.04
+      - image: cimg/base:2022.04
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.7
+      # - setup_remote_docker:
+      #     version: 20.10.7
       - run:
           name: Skip ci
           command: |

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.10-alpine
+FROM python:3.12.0b3-alpine3.17
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,9 +1,8 @@
-FROM alpine:3.18.2
+FROM python:3.12.0b3-alpine
 
 RUN apk update && \
-    apk add --no-cache python3 py3-pip libpq python3-dev && \
-    apk add --update --virtual build-deps tzdata gcc libc-dev linux-headers && \
-    apk add jpeg-dev zlib-dev && \
+    apk add --update --virtual build-deps gcc libc-dev linux-headers && \
+    apk add jpeg-dev zlib-dev libpq python3-dev && \
     apk add postgresql-dev && \
     apk add netcat-openbsd
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.12.0b2-slim-bookworm
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.7-alpine
+FROM python:3.12.0b3-alpine3.18
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0b3-alpine
+FROM python:3.10.10-alpine
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.10-alpine
+FROM python:3.12.0b3-alpine
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0b3-alpine3.17
+FROM python:3.12.0b2-slim-bookworm
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -6,6 +6,8 @@ RUN apk update && \
     apk add postgresql-dev && \
     apk add netcat-openbsd
 
+RUN rm /sbin/apk
+
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0b2-slim-bookworm
+FROM python:3.10.7-alpine
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3.12.0b3-alpine3.18
+FROM alpine:3.18.2
 
 RUN apk update && \
-    apk add --update --virtual build-deps gcc libc-dev linux-headers && \
+    apk add --no-cache python3 py3-pip libpq python3-dev && \
+    apk add --update --virtual build-deps tzdata gcc libc-dev linux-headers && \
     apk add jpeg-dev zlib-dev && \
     apk add postgresql-dev && \
     apk add netcat-openbsd
-
-RUN rm /sbin/apk
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0b2-slim-bookworm
+FROM python:3.11-alpine
 
 RUN apk update && \
     apk add --update --virtual build-deps gcc libc-dev linux-headers && \

--- a/memberships/tests/test_member_model.py
+++ b/memberships/tests/test_member_model.py
@@ -28,7 +28,7 @@ class MemberModelTestCase(StripeTestCase):
             password=TEST_USER_PASSWORD,
             birth_date="1991-01-01",
         )
-        self.assertEquals(member.full_name, member.preferred_name)
+        self.assertEqual(member.full_name, member.preferred_name)
 
     def test_preferred_name_can_be_specified(self):
         member = Member.create(
@@ -48,4 +48,4 @@ class MemberModelTestCase(StripeTestCase):
             password=TEST_USER_PASSWORD,
             birth_date="1991-01-01",
         )
-        self.assertEquals("example_stripe_customer", member.stripe_customer_id)
+        self.assertEqual("example_stripe_customer", member.stripe_customer_id)

--- a/memberships/tests/test_registration_form.py
+++ b/memberships/tests/test_registration_form.py
@@ -24,8 +24,7 @@ class RegisterFormTestCase(StripeTestCase):
             birth_date="1991-01-01",
         )
 
-        self.client.login(username="test@example.com",
-                          password=TEST_USER_PASSWORD)
+        self.client.login(username="test@example.com", password=TEST_USER_PASSWORD)
 
         response = self.client.get(reverse("register"))
         self.assertEqual(response.status_code, 302)
@@ -37,12 +36,9 @@ class RegisterFormTestCase(StripeTestCase):
         self.assertFormError(response, "form", "email", required_string)
         self.assertFormError(response, "form", "password", required_string)
         self.assertFormError(response, "form", "birth_date", required_string)
-        self.assertFormError(
-            response, "form", "constitution_agreed", required_string)
-        self.assertFormError(
-            response, "form", "constitutional_post", required_string)
-        self.assertFormError(
-            response, "form", "constitutional_email", required_string)
+        self.assertFormError(response, "form", "constitution_agreed", required_string)
+        self.assertFormError(response, "form", "constitutional_post", required_string)
+        self.assertFormError(response, "form", "constitutional_email", required_string)
 
     def test_donation_is_required_to_be_a_number(self):
         response = self.client.post(
@@ -92,8 +88,7 @@ class RegisterFormTestCase(StripeTestCase):
                 "donation": 10,
             },
         )
-        self.assertRedirects(
-            response, "{}?donation=10".format(reverse("confirm")))
+        self.assertRedirects(response, "{}?donation=10".format(reverse("confirm")))
 
     def test_member_is_redirected_to_confirm_page_without_donation_when_not_provided(
         self,
@@ -129,8 +124,10 @@ class RegisterFormTestCase(StripeTestCase):
             response,
             "form",
             "password",
-            ["This password is too short. It must contain at least 10 characters.",
-             "This password is too common."]
+            [
+                "This password is too short. It must contain at least 10 characters.",
+                "This password is too common.",
+            ],
         )
 
     def test_existing_member_cannot_reregister(self):
@@ -184,10 +181,8 @@ class DonationConfirmPageTestCase(StripeTestCase):
         self.assertRedirects(response, reverse("register"))
 
     def test_total_with_donation_shows_correct_amount(self):
-        response = self.client.get(
-            "{}?donation={}".format(reverse("confirm"), 10.00))
-        self.assertContains(
-            response, "Your membership will cost £11.00 a year")
+        response = self.client.get("{}?donation={}".format(reverse("confirm"), 10.00))
+        self.assertContains(response, "Your membership will cost £11.00 a year")
         self.assertContains(
             response,
             "This is made up of a £1 membership charge and a £10.00 donation",
@@ -205,13 +200,11 @@ class DonationConfirmPageTestCase(StripeTestCase):
     @mock.patch("django.conf.settings.STRIPE_PUBLIC_KEY", "example_stripe_key")
     def test_view_has_stripe_public_key(self):
         response = self.client.get(reverse("confirm"))
-        self.assertEqual(
-            response.context["stripe_public_key"], "example_stripe_key")
+        self.assertEqual(response.context["stripe_public_key"], "example_stripe_key")
 
     def test_view_has_stripe_session_id(self):
         response = self.client.get(reverse("confirm"))
-        self.assertEqual(
-            response.context["stripe_session_id"], "example_session_id")
+        self.assertEqual(response.context["stripe_session_id"], "example_session_id")
 
     def test_users_without_a_donation_are_sent_to_the_correct_cancel_and_success_urls(
         self,

--- a/memberships/tests/test_registration_form.py
+++ b/memberships/tests/test_registration_form.py
@@ -24,7 +24,8 @@ class RegisterFormTestCase(StripeTestCase):
             birth_date="1991-01-01",
         )
 
-        self.client.login(username="test@example.com", password=TEST_USER_PASSWORD)
+        self.client.login(username="test@example.com",
+                          password=TEST_USER_PASSWORD)
 
         response = self.client.get(reverse("register"))
         self.assertEqual(response.status_code, 302)
@@ -36,9 +37,12 @@ class RegisterFormTestCase(StripeTestCase):
         self.assertFormError(response, "form", "email", required_string)
         self.assertFormError(response, "form", "password", required_string)
         self.assertFormError(response, "form", "birth_date", required_string)
-        self.assertFormError(response, "form", "constitution_agreed", required_string)
-        self.assertFormError(response, "form", "constitutional_post", required_string)
-        self.assertFormError(response, "form", "constitutional_email", required_string)
+        self.assertFormError(
+            response, "form", "constitution_agreed", required_string)
+        self.assertFormError(
+            response, "form", "constitutional_post", required_string)
+        self.assertFormError(
+            response, "form", "constitutional_email", required_string)
 
     def test_donation_is_required_to_be_a_number(self):
         response = self.client.post(
@@ -88,7 +92,8 @@ class RegisterFormTestCase(StripeTestCase):
                 "donation": 10,
             },
         )
-        self.assertRedirects(response, "{}?donation=10".format(reverse("confirm")))
+        self.assertRedirects(
+            response, "{}?donation=10".format(reverse("confirm")))
 
     def test_member_is_redirected_to_confirm_page_without_donation_when_not_provided(
         self,
@@ -124,10 +129,8 @@ class RegisterFormTestCase(StripeTestCase):
             response,
             "form",
             "password",
-            "This password is too short. It must contain at least 10 characters.",
-        )
-        self.assertFormError(
-            response, "form", "password", "This password is too common."
+            ["This password is too short. It must contain at least 10 characters.",
+             "This password is too common."]
         )
 
     def test_existing_member_cannot_reregister(self):
@@ -181,8 +184,10 @@ class DonationConfirmPageTestCase(StripeTestCase):
         self.assertRedirects(response, reverse("register"))
 
     def test_total_with_donation_shows_correct_amount(self):
-        response = self.client.get("{}?donation={}".format(reverse("confirm"), 10.00))
-        self.assertContains(response, "Your membership will cost £11.00 a year")
+        response = self.client.get(
+            "{}?donation={}".format(reverse("confirm"), 10.00))
+        self.assertContains(
+            response, "Your membership will cost £11.00 a year")
         self.assertContains(
             response,
             "This is made up of a £1 membership charge and a £10.00 donation",
@@ -200,11 +205,13 @@ class DonationConfirmPageTestCase(StripeTestCase):
     @mock.patch("django.conf.settings.STRIPE_PUBLIC_KEY", "example_stripe_key")
     def test_view_has_stripe_public_key(self):
         response = self.client.get(reverse("confirm"))
-        self.assertEqual(response.context["stripe_public_key"], "example_stripe_key")
+        self.assertEqual(
+            response.context["stripe_public_key"], "example_stripe_key")
 
     def test_view_has_stripe_session_id(self):
         response = self.client.get(reverse("confirm"))
-        self.assertEqual(response.context["stripe_session_id"], "example_session_id")
+        self.assertEqual(
+            response.context["stripe_session_id"], "example_session_id")
 
     def test_users_without_a_donation_are_sent_to_the_correct_cancel_and_success_urls(
         self,

--- a/memberships/tests/test_stripe_gateway.py
+++ b/memberships/tests/test_stripe_gateway.py
@@ -23,7 +23,7 @@ class StripeGatewayTestCase(TestCase):
         customer_id = stripe_gateway.upload_member(email="test@example.com")
 
         create_customer.assert_called_with(email="test@example.com")
-        self.assertEquals("example_customer_id", customer_id)
+        self.assertEqual("example_customer_id", customer_id)
 
     @mock.patch("stripe.checkout.Session.create", autospec=True)
     def test_create_checkout_session_creates_a_stripe_bacs_session(
@@ -43,7 +43,7 @@ class StripeGatewayTestCase(TestCase):
             success_url="success-url",
             cancel_url="cancel-url",
         )
-        self.assertEquals("example_session_id", session_id)
+        self.assertEqual("example_session_id", session_id)
 
     @mock.patch("stripe.Customer.retrieve", autospec=True)
     @mock.patch("stripe.SetupIntent.retrieve", autospec=True)
@@ -63,7 +63,7 @@ class StripeGatewayTestCase(TestCase):
             default_payment_method="a_payment_method",
             items=[{"price": stripe_gateway.membership_price_id}],
         )
-        self.assertEquals(
+        self.assertEqual(
             {"id": "stripe_subscription_id", "email": "test@example.com"},
             result,
         )

--- a/memberships/views.py
+++ b/memberships/views.py
@@ -5,7 +5,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 from django.views.decorators.csrf import csrf_exempt
 from django.conf import settings
@@ -251,7 +251,7 @@ def sendVerification(request):
 
 def verify(request, uidb64, token):
     try:
-        uid = force_text(urlsafe_base64_decode(uidb64))
+        uid = force_str(urlsafe_base64_decode(uidb64))
         user = User.objects.get(pk=uid)
         m = request.user
     except (TypeError, ValueError, User.DoesNotExist, OverflowError):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backports.functools-lru-cache>=1.6.4
 beautifulsoup4==4.9.3
 certifi==2022.12.7
 chardet==4.0.0
-Django==3.2.18
+Django==4.2.1
 django-environ==0.4.5
 django-extensions==3.1.1
 django-livereload-server~=0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backports.functools-lru-cache>=1.6.4
 beautifulsoup4==4.9.3
 certifi==2022.12.7
 chardet==4.0.0
-Django==3.2.18
+Django==4.2.2
 django-environ==0.4.5
 django-extensions==3.1.1
 django-livereload-server~=0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backports.functools-lru-cache>=1.6.4
 beautifulsoup4==4.9.3
 certifi==2022.12.7
 chardet==4.0.0
-Django==4.2.1
+Django==4.1.9
 django-environ==0.4.5
 django-extensions==3.1.1
 django-livereload-server~=0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backports.functools-lru-cache>=1.6.4
 beautifulsoup4==4.9.3
 certifi==2022.12.7
 chardet==4.0.0
-Django==4.1.9
+Django==3.2.18
 django-environ==0.4.5
 django-extensions==3.1.1
 django-livereload-server~=0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ django-widget-tweaks~=1.4
 idna==2.10
 importlib-metadata>=6.6.0
 Pillow==9.4.0
-psycopg2-binary==2.9.3
-pytz==2021.1
+psycopg2==2.9.6
+pytz==2023.3
 requests==2.31.0
 six==1.16.0
 soupsieve~=2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asgiref~=3.3
 backports.functools-lru-cache>=1.6.4
 beautifulsoup4==4.9.3
+cached-property==1.5.2
 certifi==2022.12.7
 chardet==4.0.0
 Django==4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backports.functools-lru-cache>=1.6.4
 beautifulsoup4==4.9.3
 certifi==2022.12.7
 chardet==4.0.0
-Django~=3.2.19
+Django==3.2.18
 django-environ==0.4.5
 django-extensions==3.1.1
 django-livereload-server~=0.3
@@ -24,6 +24,6 @@ tornado==6.3.2
 urllib3>=1.26.5
 celery==5.2.2
 django-clacks>=0.1.0
-cookiecutter>=2.1.1 # not directly required, pinned by Snyk to avoid a vulnerability
+cookiecutter==2.1.1 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 typing-extensions>=4.5.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ requests==2.31.0
 six==1.16.0
 soupsieve~=2.2
 sqlparse==0.4.4
-stripe==2.56.0
+stripe==5.4.0
 tornado==6.3.2
 urllib3>=1.26.5
 celery==5.2.2


### PR DESCRIPTION
<!--- ^ Provide a general summary of your changes in the Title above ^ -->

- We want the cicd pipeline not to build a new image when the branch that kicks the PR is named `doc-*`, which means that only the documentation was updated.
- We also need the Python version in the Dockerfile to be updated to 3.12.0b3-alpine, as suggested by Snyk (see #677)
- We want to use psycopg2 instead psycopg2-binary, as the latter should not be used in production.
- We need to change the executor used in the cicd pipeline, as the one currently configured for some reason creates a Geek Zone backend image with an older version of Python, which makes Snyk fail the pipeline.

## Description

- We are adding a step in the cicd pipeline with a conditional statement that will make it stop running if the branch that kicked it is named `doc-*`. However, the pipeline will show success, which is what we need to pass the PR checks.
-  We also updated Python version from 3.10.10-alpine to 3.12.0b3-alpine. This change needs some other changes in the Python files, without which the tests will fail (see a long list of recently failed cicd pipelines).
- We switched from psycopg2-binary to psycopg2, which in turn needed a couple of dependencies to be added in the Dockerfile to work.
- We switched from "machine" executor to "docker" executor.

## Related Issue
"resolves #674 #681"

## Motivation and Context
The change is needed because at the moment any PR started from a branch named `doc-*` will not pass the cicd check. This is because the current cicd configuration makes the pipeline not run at all in such a scenario, thus the required cicd check will fail.
Updating the Python version is needed to pass the Snyk checks, while all the modifications in the Python files are needed to pass the tests. 
Two packages were needed to switch from psycopg2-binary to psycopg2, which is not meant to be used in production.
The executor configured for the cicd pipeline caused Snyk to fail the image.

## How Has This Been Tested?
The logic that prevents the cicd pipeline to build a new image when only documentation is updated was tested in this cicd pipeline: https://app.circleci.com/pipelines/github/GeekZoneHQ/web/1972/workflows/58936093-d33c-4774-a133-cc0a0684a05a
All the other changes were tested in the cicd pipeline, as shown in the passed check.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/GeekZoneHQ/contributing)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
