### PR TITLE
Revert "Updated GeekZone executor image"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   deploy-test:
     docker:
-      - image: "geekzone/infra:0.1.410"
+      - image: "geekzone/infra:0.1.403"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   deploy-prod:
     docker:
-      - image: "geekzone/infra:0.1.410"
+      - image: "geekzone/infra:0.1.403"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:


### PR DESCRIPTION
Reverts GeekZoneHQ/web#707 as the deployment into the cluster in "Prod" failed.