### PR TITLE
Updated GeekZone executor image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,7 @@ jobs:
 
   deploy-test:
     docker:
-<<<<<<< HEAD
       - image: "geekzone/infra:0.1.413"
-=======
-      - image: "geekzone/infra:0.1.410"
->>>>>>> main
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   deploy-test:
     docker:
-      - image: "geekzone/infra:0.1.409"
+      - image: "geekzone/infra:0.1.410"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   deploy-prod:
     docker:
-      - image: "geekzone/infra:0.1.409"
+      - image: "geekzone/infra:0.1.410"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   deploy-test:
     docker:
-      - image: "geekzone/infra:0.1.406"
+      - image: "geekzone/infra:0.1.409"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   deploy-prod:
     docker:
-      - image: "geekzone/infra:0.1.406"
+      - image: "geekzone/infra:0.1.409"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   deploy-test:
     docker:
-      - image: "geekzone/infra:0.1.410"
+      - image: "geekzone/infra:0.1.413"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   deploy-prod:
     docker:
-      - image: "geekzone/infra:0.1.410"
+      - image: "geekzone/infra:0.1.413"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   deploy-test:
     docker:
-      - image: "geekzone/infra:0.1.403"
+      - image: "geekzone/infra:0.1.406"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   deploy-prod:
     docker:
-      - image: "geekzone/infra:0.1.403"
+      - image: "geekzone/infra:0.1.406"
     environment:
       TAG: 0.1.<< pipeline.number >>
     steps:


### PR DESCRIPTION
## Description
The GeekZone executor image needs to be updated to use the Azure Postgres flexible server instead of the Azure Postgres single server.

## Related Issue
"resolves https://github.com/GeekZoneHQ/web/issues/706 "

## Motivation and Context
The Azure Postgres single server has reached the end of support and does not support newer versions of Postgres, which are required by the Django version used by the Geek Zone app.

## How Has This Been Tested?
This PR will be used as a test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/GeekZoneHQ/contributing)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
